### PR TITLE
V0.5routes update

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -56,7 +56,7 @@ def test_get_single_model(client, logger):
     assert model.modelId == model_copy.modelId
 
 def test_get_model_by_name(client, logger):
-    model = client.models.get_by_name("Sentiment Analysis")  # by name
+    model = client.models.get_by_name("Military Equipment Classification")  # by name
     logger.debug("model_modelId: %s", model.modelId)
     assert model.modelId
     logger.debug("model_latestVersion: %s", model.latestVersion)

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -16,6 +16,14 @@ API_KEY = os.getenv('MODZY_API_KEY')
 MODEL_ID = 'ed542963de'  # sentiment-analysis
 BLOCK_TIMEOUT = 600  # how long to wait until giving up on real api
 
+@pytest.fixture()
+def client():
+    return ApiClient(base_url=BASE_URL, api_key=API_KEY)
+
+@pytest.fixture()
+def logger():
+    return logging.getLogger(__name__)
+
 def test_get_results(client, logger):
     job = client.jobs.submit_text(MODEL_ID, '0.0.27', {'input.txt': 'Modzy is great!'})
     logger.debug("job %s", job)

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -36,7 +36,7 @@ def test_get_all_tags(client, logger):
 
 
 def test_get_tags_and_models(client, logger):
-    tags, models = client.tags.get_tags_and_models('computer-vision')  # by identifier
+    tags, models = client.tags.get_tags_and_models('computer_vision')  # by identifier
     logger.debug("tags by computer_vision: %d", len(models))
     for tag in tags:
         logger.debug("tag: %s", tag)


### PR DESCRIPTION
## Description

This pr add support for some small changes on the job API services and some small fixes:

- The response of the route `jobs/post` doesn't return the status of the job anymore.
- The response of the route `jobs/post` returns the info before the job is actually created in the database.

## Related issues

No issues related

## Tests

- https://github.com/modzy/sdk-python/blob/c370c1dc8d0390e9e4df9a8b31b6c2feae7d5cad/tests/test_jobs.py#L160-L167
- https://github.com/modzy/sdk-python/blob/c370c1dc8d0390e9e4df9a8b31b6c2feae7d5cad/tests/test_jobs.py#L170-L183

## Checklist

- [x] I read the Contributing guide.
- [x] I update the documentation and if the case the README.md file.
- [x] I am willing to follow-up on review comments in a timely manner.
