### PR TITLE
feature: adds processing engine functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,9 @@ Currently we support the following API routes:
 |Retrieve related models|client.models.get_related()|[api/models/:model-id/related-models](https://models.modzy.com/docs/models/marketplace/retrieve-related-models)|
 |Retrieve model versions|client.models.get_versions()|[api/models/:model-id/versions](https://models.modzy.com/docs/versions/marketplace/retrieve-versions)|
 |Retrieve model version details|client.models.get_version()|[api/models/:model-id/versions/:version-id](https://models.modzy.com/docs/versions/marketplace/retrieve-version-details)|
-|Retrieve all tags|client.tags.get_all()|[api/models/tags](https://models.modzy.com/docs/tags/marketplace/retrieve-tags)|
+|Update processing engines|client.models.update_processing_engines()|[api/resource/models](https://models.modzy.com/docs/management/processing/get-model-details)|
+|Retrieve minimum engines|client.models.get_minimum_engines()|[api/models/processing-engines](https://models.modzy.com/docs/management/processing/get-minimum-engines)|
+|Retrieve all tags|client.tags.get_all()|[api/models/tags](https://models.modzy.com/docs/management/processing/get-minimum-engines/marketplace/retrieve-tags)|
 |Retrieve Tags and Models|client.tags.get_tags_and_models()|[api/models/tags/:tag-id](https://models.modzy.com/docs/tags/marketplace/retrieve-models-by-tags) |
 |Submit a Job (Single Text)|client.jobs.submit_text()|[api/jobs](https://models.modzy.com/docs/jobs/job-inputs/submit-job)|
 |Submit a Job (Multiple Text)|client.jobs.submit_text_bulk()|[api/jobs](https://models.modzy.com/docs/jobs/job-inputs/submit-job)|

--- a/modzy/accounting.py
+++ b/modzy/accounting.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+"""Classes for interacting with results."""
+
+import logging
+from typing import List
+
+from ._api_object import ApiObject
+
+
+class Accounting:
+    """The `Accounting` object.
+
+    This object is used to retrieve information about accounting from the API.
+
+    Note:
+        This class should not be instantiated directly but rather accessed through the `accounting`
+        attribute of an `ApiClient` instance.
+    """
+
+    _base_route = '/accounting'
+
+    def __init__(self, api_client):
+        """Creates a `Accounting` instance.
+
+        Args:
+            api_client (ApiClient): An `ApiClient` instance.
+        """
+        self._api_client = api_client
+        self.logger = logging.getLogger(__name__)
+
+    def list_entitlements(self) -> List[ApiObject]:
+        """
+        Obtains a detailed list of all the entitlements associated with the current client.
+
+        Returns:
+            entitlements: list of ApiObjects containing metadata for each entitlement present
+        """
+        endpoint = f"{self._base_route}/entitlements"
+        entitlements = self._api_client.http.get(endpoint)
+        return entitlements
+
+    def has_entitlement(self, entitlement_identifier: str) -> bool:
+        """
+        Determines if the Modzy client user has the provided endpoint
+
+        Args:
+            entitlement_identifier: single identifier that can be found in reference
+                https://models.modzy.com/docs/api-reference-guides/authorization
+
+        Returns:
+            _has_entitlement: True if the current client has the entitlement, false otherwise
+        """
+        entitlement_identifiers = [entitlement["identifier"] for entitlement in self.list_entitlements()]
+        _has_entitlement = entitlement_identifier in entitlement_identifiers
+        self.logger.info(f"Entitlement `{entitlement_identifier}` {'' if _has_entitlement else 'not '}found")
+        return _has_entitlement

--- a/modzy/client.py
+++ b/modzy/client.py
@@ -6,6 +6,7 @@ from .jobs import Jobs
 from .models import Models
 from .results import Results
 from .tags import Tags
+from .accounting import Accounting
 
 
 class ApiClient:
@@ -46,6 +47,7 @@ class ApiClient:
 
         self.http = HttpClient(self)
 
+        self.accounting = Accounting(self)
         self.models = Models(self)
         self.jobs = Jobs(self)
         self.results = Results(self)

--- a/modzy/models.py
+++ b/modzy/models.py
@@ -58,7 +58,7 @@ class Models:
         return None
 
     def get_minimum_engines(self) -> int:
-        """Obtains the total amount of processing engines set as the minimum processing capacity"""
+        """Obtains the total amount of processing engines set as the minimum processing capacity across all models."""
         route = f"{self._base_route}/processing-engines"
         raw_result = self._api_client.http.get(route)
         minimum_engines_sum = int(raw_result["minimumProcessingEnginesSum"])
@@ -92,7 +92,6 @@ class Models:
         model_id = Model._coerce_identifier(model)
 
         admin_entitlement = "CAN_PATCH_PROCESSING_MODEL_VERSION"
-        data_scientist_entitlement = "CAN_PATCH_MODEL_VERSIONS"
         admin = self._api_client.accounting.has_entitlement(admin_entitlement)
 
         base_request_body = {

--- a/modzy/models.py
+++ b/modzy/models.py
@@ -5,8 +5,10 @@ import logging
 from datetime import datetime
 from ._api_object import ApiObject
 from urllib.parse import urlencode
-from .error import NotFoundError
-
+from .error import NotFoundError, ForbiddenError, BadRequestError
+from typing import Union
+from time import time as t
+from time import sleep
 
 class Models:
     """The `Models` object.
@@ -28,6 +30,129 @@ class Models:
         """
         self._api_client = api_client
         self.logger = logging.getLogger(__name__)
+
+    def get_model_details(self, model, version):
+        """
+        Checks to see if a model with a certain id and version is active, and if it is, will return the model
+        details for that particular model.
+
+        Args:
+            model: model id, or `Model` instance
+            version: semantic version of previously specified model
+
+        Returns:
+            model: The model details for the model with the id and version specified or None if there are no active
+            models with these parameters
+
+        """
+        model_id = Model._coerce_identifier(model)
+
+        # TODO: this changed from being in the models api to the resources api,
+        #  so maybe it should go in a different module?
+        endpoint = "/resources/processing/models"
+
+        required_entitlements = "CAN_VIEW_MODELS_PROCESSING_STATE"
+        allowed = self._api_client.accounting.has_entitlement(required_entitlements)
+        if not allowed:
+            error_message = \
+                f"In order to get usage details, you must have the following entitlement: {required_entitlements}"
+            raise ForbiddenError(error_message, self._api_client, None)
+
+        result = self._api_client.http.get(endpoint)
+
+        for model in result:
+            if model["identifier"] == model_id and model["version"] == version:
+                return model
+        return None
+
+    def get_minimum_engines(self) -> int:
+        """Obtains the total amount of processing engines set as the minimum processing capacity"""
+        route = f"{self._base_route}/processing-engines"
+        raw_result = self._api_client.http.get(route)
+        minimum_engines_sum = int(raw_result["minimumProcessingEnginesSum"])
+
+        self.logger.info(f"The sum of minimum processing engines is: {minimum_engines_sum}")
+        return minimum_engines_sum
+
+    def update_processing_engines(
+        self, model, version: str, min_engines: int, max_engines: int, timeout: int = 0, poll_rate: int = 5
+    ):
+        """
+        Updates the minimum and maximum processing engines for a specific model identifier and version.
+
+        Args:
+            model: model id, or `Model` instance
+            version: semantic version of previously specified model
+            min_engines: minimum number of processing engines allowed for this model and version
+            max_engines: maximum number of processing engines allowed for this model and version
+            timeout: time in seconds to wait until processing engine is spun up. 0 means return immediately, None means
+            block and wait forever
+            poll_rate: If timeout is nonzero, this value will determine the rate at which the state of the cluster
+            is checked
+
+        Raises:
+            ForbiddenError: Occurs if the current API client does not have the appropriate entitlements in order
+            to update processing engines
+        """
+        if not max_engines >= min_engines:
+            raise ValueError("Your min_engines value may not exceed the max_engines value")
+
+        model_id = Model._coerce_identifier(model)
+
+        admin_entitlement = "CAN_PATCH_PROCESSING_MODEL_VERSION"
+        data_scientist_entitlement = "CAN_PATCH_MODEL_VERSIONS"
+        admin = self._api_client.accounting.has_entitlement(admin_entitlement)
+        data_scientist = self._api_client.accounting.has_entitlement(data_scientist_entitlement)
+
+        base_request_body = {
+            "minimumParallelCapacity": min_engines,
+            "maximumParallelCapacity": max_engines
+        }
+        base_endpoint = f"{self._base_route}/{model_id}/versions/{version}"
+
+        if admin:
+            endpoint = f"{base_endpoint}/processing"
+            request_body = base_request_body
+        elif data_scientist:
+            endpoint = base_endpoint
+            request_body = {
+                "processing": base_request_body
+            }
+        else:
+            error_message = "You are not authorized to update processing engines. You will need one of the following" \
+                            f"endpoints in order to process: {admin_entitlement}, {data_scientist_entitlement}"
+            raise ForbiddenError(error_message, self._base_route, None)
+
+        try:
+            result = self._api_client.http.patch(endpoint, json_data=request_body)
+            self.logger.info(
+                f"Updated processing engines for Model {model_id} {version}: \n{result['processing']}"
+            )
+        except BadRequestError as e:
+            error_message = e.message
+            self.logger.error(error_message)
+            raise ValueError(error_message)
+
+        if timeout == 0:
+            return
+        else:
+            assert timeout is None or timeout > 0, \
+                "Timeout must either be an integer >= 0 or None to indicate no timeout"
+            start_time = t()
+            while True:
+                current_time = t() - start_time
+                if timeout is not None and current_time > timeout:
+                    self.logger.warning(
+                        f"Timeout of {timeout} seconds reached while waiting for processing engines to initialize."
+                    )
+                    return
+                model_details = self.get_model_details(model_id, version)
+                if model_details is not None:  # This means the model with the id and version is now visible
+                    engines_ready = sum([engine["ready"] for engine in model_details["engines"]])
+                    if engines_ready >= min_engines:
+                        self.logger.info(f"{engines_ready} engines are ready.")
+                        return
+                sleep(poll_rate)
 
     def get(self, model):
         """Gets a `Model` instance.
@@ -254,6 +379,7 @@ class Models:
         self.logger.debug("body 2? %s", body)
         json_list = self._api_client.http.get('{}?{}'.format(self._base_route, urlencode(body)))
         return list(Model(json_obj, self._api_client) for json_obj in json_list)
+
 
 class Model(ApiObject):
     """A model object.

--- a/modzy/models.py
+++ b/modzy/models.py
@@ -31,7 +31,7 @@ class Models:
         self._api_client = api_client
         self.logger = logging.getLogger(__name__)
 
-    def get_model_details(self, model, version):
+    def get_model_processing_details(self, model, version):
         """
         Checks to see if a model with a certain id and version is active, and if it is, will return the model
         details for that particular model.
@@ -132,7 +132,7 @@ class Models:
                         f"Timeout of {timeout} seconds reached while waiting for processing engines to initialize."
                     )
                     return
-                model_details = self.get_model_details(model_id, version)
+                model_details = self.get_model_processing_details(model_id, version)
                 if model_details is not None:  # This means the model with the id and version is now visible
                     engines_ready = sum([engine["ready"] for engine in model_details["engines"]])
                     if engines_ready >= min_engines:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.5.3
+current_version = 0.5.5
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/modzy/sdk-python',
-    version='0.5.3',
+    version='0.5.5',
     zip_safe=False,
 )

--- a/tests/test_accounting.py
+++ b/tests/test_accounting.py
@@ -1,0 +1,28 @@
+import os
+import dotenv
+import pytest
+from modzy import ApiClient
+import logging
+
+dotenv.load_dotenv()
+
+BASE_URL = os.getenv('MODZY_BASE_URL')
+API_KEY = os.getenv('MODZY_API_KEY')
+
+
+@pytest.fixture()
+def client():
+    return ApiClient(base_url=BASE_URL, api_key=API_KEY)
+
+
+@pytest.fixture()
+def logger():
+    return logging.getLogger(__name__)
+
+
+def test_list_entitlements(client):
+    client.accounting.list_entitlements()
+
+
+# def test_has_entitlement(client):
+#     assert client.accounting.has_entitlement("CAN_PATCH_PROCESSING_MODEL_VERSION")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -120,3 +120,26 @@ def test_get_model_version_output_sample(client, logger):
     output_sample = client.models.get_version_output_sample(MODEL_ID, '0.0.27')
     logger.debug("version: %s", output_sample)
     assert output_sample
+
+
+def test_get_model_details(client):
+    client.models.get_model_details(MODEL_ID, "0.0.27")
+
+
+def test_get_minimum_engines(client):
+    client.models.get_minimum_engines()
+
+
+def test_update_processing_state(client):
+    client.models.update_processing_engines(MODEL_ID, "0.0.27", 0, 1)
+
+
+def test_update_processing_state_wait(client):
+    client.models.update_processing_engines(MODEL_ID, "0.0.27", 2, 2, None)
+
+
+@pytest.mark.parametrize("engine_min_max", [(100, 200), (1, 0)])
+def test_processing_state_errors(client, engine_min_max):
+    min_engines, max_engines = engine_min_max
+    with pytest.raises(ValueError):
+        client.models.update_processing_engines(MODEL_ID, "0.0.27", min_engines, max_engines)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -122,8 +122,8 @@ def test_get_model_version_output_sample(client, logger):
     assert output_sample
 
 
-def test_get_model_details(client):
-    client.models.get_model_details(MODEL_ID, "0.0.27")
+def test_get_model_processing_details(client):
+    client.models.get_model_processing_details(MODEL_ID, "0.0.27")
 
 
 def test_get_minimum_engines(client):


### PR DESCRIPTION
## Description

This PR extends adds an accounting module in order to easy check entitlements, as well as extends the models module in order to allow users to set the number of processing engines that they would like to use for a model with the potential to busy wait

## Tests

I added test coverage for the new functionality that I added

## Checklist

- [X] I read the Contributing guide.
- [X] I update the documentation and if the case the README.md file.
- [X] I am willing to follow-up on review comments in a timely manner.
