### PR TITLE
fix typo

### DIFF
--- a/modzy/jobs.py
+++ b/modzy/jobs.py
@@ -31,7 +31,7 @@ class Jobs:
         IN_PROGRESS='IN_PROGRESS',
         COMPLETED='COMPLETED',
         CANCELED='CANCELED',
-        TIMEOUT='TIMEOUT',
+        TIMEDOUT='TIMEDOUT',
     )
     """Possible job statuses."""
 


### PR DESCRIPTION
fix: typo TIMEOUT should be TIMEDOUT

## Description

Just fixing a typo in job status

