### PR TITLE
fix: solve the missing key in results

### DIFF
--- a/modzy/results.py
+++ b/modzy/results.py
@@ -177,7 +177,7 @@ class Result(ApiObject):
             if source_name in source:  # deal with legacy double nesting of source source_name
                 source = source[source_name]
             return source
-        except KeyError:
+        except (KeyError, AttributeError):
             pass
 
         try:
@@ -185,7 +185,7 @@ class Result(ApiObject):
             if source_name in source:  # deal with legacy double nesting of source source_name
                 source = source[source_name]
             raise ResultsError(source.error)
-        except KeyError:
+        except (KeyError, AttributeError):
             pass
 
         # TODO: can we give a better error message if job canceled?
@@ -218,12 +218,12 @@ class Result(ApiObject):
     def _get_first_source_name(self):
         try:
             return next(iter(self.results))
-        except StopIteration:
+        except (StopIteration, AttributeError):
             pass
 
         try:
             return next(iter(self.failures))
-        except StopIteration:
+        except (StopIteration, AttributeError):
             pass
 
         # TODO: can we give a better error message if job canceled?


### PR DESCRIPTION
## Description

When a Job fails to process (the model report an error processing the inputs provided), the SDK was showing a key error like this one:

```
results.get_first_outputs() (python sdk) fails if job was a failure "'Result' object has no attribute 'results'"
```

## Related issues

There are no issues reported externally 

## Tests

We try again and now the response is a ResultError as expected

## Checklist

- [x] I read the Contributing guide.
- [x] I update the documentation and if the case the README.md file.
- [x] I am willing to follow-up on review comments in a timely manner.
