### PR TITLE
feat: adding an initial validation to the base_url 

### DIFF
--- a/modzy/client.py
+++ b/modzy/client.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
 """The API client implementation."""
-
+from .error import NetworkError
 from .http import HttpClient
 from .jobs import Jobs
 from .models import Models
 from .results import Results
 from .tags import Tags
+import logging
 
 
 class ApiClient:
@@ -38,17 +39,37 @@ class ApiClient:
             api_key (str): The API key to use for authentication.
             certs (str): A tuple to use custom cert and key, i.e.: (cert_file_path, key_file_path)
         """
-        if base_url is None or base_url == "":
-            raise ValueError("Cannot initialize the modzy client: the base_url param should be a valid not empty string")
-        if api_key is None or api_key == "":
-            raise ValueError("Cannot initialize the modzy client: the api_key param should be a valid not empty string")
+        self.logger = logging.getLogger(__name__)
         self.base_url = base_url
         self.api_key = api_key
         self.cert = cert
 
         self.http = HttpClient(self)
-        
+        self.check_client()
+
         self.models = Models(self)
         self.jobs = Jobs(self)
         self.results = Results(self)
         self.tags = Tags(self)
+
+    def check_client(self):
+        self.logger.debug("Checking base_url %s", self.base_url)
+        if self.base_url is None or self.base_url == "":
+            raise ValueError("Cannot initialize the modzy client: the base_url param should be a valid not empty string")
+        if self.api_key is None or self.api_key == "":
+            raise ValueError("Cannot initialize the modzy client: the api_key param should be a valid not empty string")
+        req_check = False
+        try:
+            self.http.get('/models')
+            req_check = True
+        except Exception as e:
+            if not self.base_url.endswith('api') and not self.base_url.endswith('api/'):
+                self.base_url = self.base_url + ("" if self.base_url.endswith("/") else "/") + "api/"
+                # Try again with the new URL
+                self.check_client()
+                req_check = True
+
+        if not req_check:
+            raise ValueError("Cannot initialize the modzy client: the base_url param should point to a valid API "
+                             "endpoint and the api_key should be a valid key for the env")
+


### PR DESCRIPTION
## Description

Is common that some users cannot identify the base URL to the API services, so this change will allow him to use the URL of the environment, i.e: https://app.modzy.com/ and will try to add the /api part at the end.

Also is a way to fail fast if something is missing, the URL or the API key are wrong.

## Related issues

There are no issues related

## Tests

I run the full test suite against the URL with and without the api part

## Checklist

- [X] I read the Contributing guide.
- [X] I update the documentation and if the case the README.md file.
- [X] I am willing to follow-up on review comments in a timely manner.
