### PR TITLE
fix: correct version number

### DIFF
--- a/modzy/__init__.py
+++ b/modzy/__init__.py
@@ -5,6 +5,6 @@ import logging
 
 from .client import ApiClient  # noqa
 
-__version__ = '0.5.2'
+__version__ = '0.6.0'
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.5.7
+current_version = 0.6.0
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/modzy/sdk-python',
-    version='0.5.7',
+    version='0.6.0',
     zip_safe=False,
 )


### PR DESCRIPTION
## Description

Updated version number to 0.6.0

## Related issues

No related issue. `modzy.__version__` was returning an older incorrect version number. 

## Tests

Imported sdk, `modzy.__version__` now correctly returns `0.6.0`.

## Checklist

- [x] I read the Contributing guide.
- [x] I update the documentation and if the case the README.md file.
- [x] I am willing to follow-up on review comments in a timely manner.
