### PR TITLE
Updated the Manifest file to prune samples and tests during packaging…

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,3 +8,6 @@ recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
 
 recursive-include docs *.rst conf.py Makefile make.bat *.jpg *.png *.gif
+
+prune samples
+prune tests

--- a/modzy/__init__.py
+++ b/modzy/__init__.py
@@ -5,6 +5,6 @@ import logging
 
 from .client import ApiClient  # noqa
 from .edge.client import EdgeClient
-__version__ = '0.7.0'
+__version__ = '0.7.1'
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open('HISTORY.rst') as history_file:
 
 requirements = ['requests', 'python-dotenv', 'deprecation', 'protobuf', 'grpcio', 'google-api-python-client']
 
-test_requirements = ['pytest']
+# removed in 0.7.1 test_requirements = ['pytest']
 
 setup(
     author='Modzy',
@@ -37,9 +37,9 @@ setup(
     keywords='modzy, sdk',
     name='modzy-sdk',
     packages=find_packages(),
-    test_suite='tests',
-    tests_require=test_requirements,
+    # removed in 0.7.1 test_suite='tests',
+    # removed in 0.7.1 tests_require=test_requirements,
     url='https://github.com/modzy/sdk-python',
-    version='0.7.0',
+    version='0.7.1',
     zip_safe=False,
 )


### PR DESCRIPTION
…. Those files will remain in the repo, but do distribute to PyPi or Conda.

also updated version.

## Description

This PR alters the SDK's packaging manifest to remove the "tests" and "samples" directories. The removals are needed for conda-forge inclusion and aren't useful to end users who pip install anyway.

## Related issues

none

## Tests

ran "pip install ." from root directory. install was successful.
ran "python setup.py sdist --formats=gztar" resulting tar ball did not have the "tests" or "samples" directories

## Checklist

- [X] I read the Contributing guide.
- [X] I update the documentation and if the case the README.md file.
- [X] I am willing to follow-up on review comments in a timely manner.
