### PR TITLE
pin protobuf version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open('README.md') as readme_file:
 with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
-requirements = ['requests', 'python-dotenv', 'deprecation', 'protobuf', 'grpcio', 'google-api-python-client']
+requirements = ['requests', 'python-dotenv', 'deprecation', 'protobuf==3.19.4', 'grpcio', 'google-api-python-client']
 
 # removed in 0.7.1 test_requirements = ['pytest']
 


### PR DESCRIPTION
## Description

Pin protobuf version to avoid incompatibility issues caused by their recent update.

## Tests

Tested import locally with pinned protobuf version.

## Checklist

- [x] I read the Contributing guide.
- [x] I update the documentation and if the case the README.md file.
- [x] I am willing to follow-up on review comments in a timely manner.
