### PR TITLE
Feat/deploy models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,9 @@ target/
 # Jupyter Notebook
 .ipynb_checkpoints
 
+# files
+deploy-test.py
+
 # pyenv
 .python-version
 

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Currently we support the following API routes:
 
 | Feature | Code |Api route
 | ---     | ---  | ---
+|Deploy new model|client.models.deploy()|[api/models](https://docs.modzy.com/reference/model-deployment)
 |Get all models|client.models.get_all()|[api/models](https://docs.modzy.com/reference/get-all-models)|
 |List models|client.models.get_models()|[api/models](https://docs.modzy.com/reference/list-models)|
 |Get model details|client.models.get()|[api/models/:model-id](https://docs.modzy.com/reference/list-model-details)|

--- a/modzy/_util.py
+++ b/modzy/_util.py
@@ -1,13 +1,16 @@
 # -*- coding: utf-8 -*-
-
+import json
 import pathlib
+import time
+from .error import NetworkError
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
 from base64 import b64encode
 
 def encode_data_uri(bytes_like, mimetype='application/octet-stream'):
     encoded = b64encode(bytes_like).decode('ascii')
     data_uri = 'data:{};base64,{}'.format(mimetype, encoded)
     return data_uri
-
 
 def file_to_bytes(file_like):
     if hasattr(file_like, 'read'):  # File-like object
@@ -31,7 +34,6 @@ def file_to_bytes(file_like):
 
     with open(path, 'rb') as file:
         return file.read()
-
 
 def file_to_chunks(file_like, chunk_size):
     file = None
@@ -65,13 +67,128 @@ def file_to_chunks(file_like, chunk_size):
     if should_close:
         file.close()
 
-
 def bytes_to_chunks(byte_array, chunk_size):
     for i in range(0, len(byte_array), chunk_size):
         yield byte_array[i:i + chunk_size]
-
 
 def depth(d):
     if d and isinstance(d, dict):
         return max(depth(v) for k, v in d.items()) + 1
     return 0
+
+'''
+Model Deployment (models.deploy()) specific utilities
+'''
+def load_model(client, logger, identifier, version):
+
+    start = time.time()
+    # Before loading the model we need to ensure that it has been pulled.
+    percentage = -1
+    while percentage < 100:
+        try:
+            res = client.http.get(f"/models/{identifier}/versions/{version}/container-image")
+            new_percentage = res.get("percentage")
+        except NetworkError:
+            continue            
+
+        if new_percentage != percentage:
+            logger.info(f'Loading model at {new_percentage}%')
+            print(f'Loading model at {new_percentage}%')
+            percentage = new_percentage
+
+        time.sleep(1)
+
+    retry_strategy = Retry(
+        total=10,
+        backoff_factor=0.3,
+        status_forcelist=[400],
+        allowed_methods=frozenset(['POST']),
+    )
+    adapter = HTTPAdapter(max_retries=retry_strategy)
+    client.http.session.mount('https://', adapter)
+
+    res = client.http.post(f"/models/{identifier}/versions/{version}/load-process")
+
+    logger.info(f'Loading container image took [{1000*(time.time()-start)} ms]')
+
+def upload_input_example(client, logger, identifier, version, model_data_metadata, input_sample_path):
+
+    start = time.time()
+
+    input_filename = model_data_metadata['inputs'][0]['name']
+    files = {'file': open(input_sample_path, 'rb')}
+    params = {'name': input_filename}
+    res = client.http.post(f"/models/{identifier}/versions/{version}/testInput", params=params, file_data=files)
+
+    logger.info(f'Uploading sample input took [{1000*(time.time()-start)} ms]')
+
+def run_model(client, logger, identifier, version):
+
+    start = time.time()
+    res = client.http.post(f"/models/{identifier}/versions/{version}/run-process")
+
+    percentage = -1
+    while percentage < 100:
+        try:
+            res = client.http.get(f"/models/{identifier}/versions/{version}/run-process")
+            new_percentage = res.get('percentage')
+        except NetworkError:
+            continue
+
+        if new_percentage != percentage:
+            logger.info(f'Running model at {new_percentage}%')
+            print(f'Running model at {new_percentage}%')
+            percentage = new_percentage
+
+        time.sleep(1)
+
+    test_output = res['result']
+
+    sample_input = {'input': {'accessKeyID': '<accessKeyID>',
+                                    'region': '<region>',
+                                    'secretAccessKey': '<secretAccessKey>',
+                                    'sources': {'0001': {'input': {'bucket': '<bucket>',
+                                                        'key': '/path/to/s3/input'}}},
+                                                        'type': 'aws-s3'},
+                                'model': {'identifier': identifier, 'version':version}
+                    }
+    
+    formatted_sample_output = {'jobIdentifier': '<uuid>',
+                                'total': '<number of inputs>',
+                                'completed': '<total number of completed inputs>',
+                                'failed': '<number of failed inputs>',
+                                'finished': '<true or false>',
+                                'submittedByKey': '<api key>',
+                                'results': {'<input-id>': {'model': None,
+                                'userIdentifier': None,
+                                'status': test_output['status'],
+                                'engine': test_output['engine'],
+                                'error': test_output['error'],
+                                'startTime': test_output['startTime'],
+                                'endTime': test_output['endTime'],
+                                'updateTime': test_output['updateTime'],
+                                'inputSize': test_output['inputSize'],
+                                'accessKey': None,
+                                'teamIdentifier': None,
+                                'accountIdentifier': None,
+                                'timeMeters': None,
+                                'datasourceCompletedTime': None,
+                                'elapsedTime': test_output['elapsedTime'],
+                                'results.json': test_output['results.json']}
+                                }
+                            }
+
+    sample_input_res = client.http.put(f"/models/{identifier}/versions/{version}/sample-input", json_data=sample_input)
+    sample_output_res = client.http.put(f"/models/{identifier}/versions/{version}/sample-output", json_data=formatted_sample_output)
+
+    logger.info(f'Inference test took [{1000*(time.time()-start)} ms]')
+
+def deploy_model(client, logger, identifier, version):
+
+    start = time.time()
+    status = {'status': 'active'}
+
+    res = client.http.patch(f"/models/{identifier}/versions/{version}", status)
+
+    logger.info(f'Model Deployment took [{1000*(time.time()-start)} ms]')
+

--- a/modzy/http.py
+++ b/modzy/http.py
@@ -48,7 +48,7 @@ class HttpClient:
         self.session = session if session is not None else requests.Session()
         self.logger = logging.getLogger(__name__)
 
-    def request(self, method, url, json_data=None, file_data=None):
+    def request(self, method, url, json_data=None, file_data=None, params=None):
         """Sends an HTTP request.
 
         The client's API key will automatically be used for authentication.
@@ -82,7 +82,7 @@ class HttpClient:
         self.logger.debug("%s: %s - [%s]", method, url, self._api_client.cert)
 
         try:
-            response = self.session.request(method, url, data=data, headers=headers, files=file_data, verify=self._api_client.cert)
+            response = self.session.request(method, url, data=data, headers=headers, files=file_data, verify=self._api_client.cert, params=params)
             self.logger.debug("response %s - length %s", response.status_code, len(response.content))
         except requests.exceptions.RequestException as ex:
             self.logger.exception('unable to make network request')
@@ -126,7 +126,7 @@ class HttpClient:
         """
         return self.request('GET', url)
 
-    def post(self, url, json_data=None, file_data=None):
+    def post(self, url, json_data=None, file_data=None, params=None):
         """Sends a POST request.
 
         Args:
@@ -140,7 +140,7 @@ class HttpClient:
             ApiError: A subclass of ApiError will be raised if the API returns an error status,
                 or the client is unable to connect.
         """
-        return self.request('POST', url, json_data=json_data, file_data=file_data)
+        return self.request('POST', url, json_data=json_data, file_data=file_data, params=params)
 
     def patch(self, url, json_data=None):
         """Sends a PATCH request.

--- a/modzy/models.py
+++ b/modzy/models.py
@@ -1,14 +1,16 @@
 # -*- coding: utf-8 -*-
 """Classes for interacting with models."""
 
+import re
+import json
 import logging
 from datetime import datetime
 from ._api_object import ApiObject
 from urllib.parse import urlencode
-from .error import NotFoundError, ResponseError
-from typing import Union
+from .error import NotFoundError, ResponseError, BadRequestError
 from time import time as t
 from time import sleep
+from ._util import load_model, upload_input_example, run_model, deploy_model
 
 class Models:
     """The `Models` object.
@@ -30,6 +32,24 @@ class Models:
         """
         self._api_client = api_client
         self.logger = logging.getLogger(__name__)
+        # model deployment specific instance variables
+        self.container_registry_regex = "^((?:[A-Za-z0-9-_]+)(?:\.[A-Za-z0-9-_]+)+\/)?([^:]+)(?::(.+))?$"
+        self.default_inputs = [
+            {
+                "name": "input",
+                "acceptedMediaTypes": "application/json",
+                "maximumSize": 1000000,
+                "description": "Default input data"
+            }
+        ]
+        self.default_outputs = [
+            {
+                "name": "results.json",
+                "mediaType": "application/json",
+                "maximumSize": 1000000,
+                "description": "Default output data"
+            }    
+        ]        
 
     def get_model_processing_details(self, model, version):
         """
@@ -47,7 +67,6 @@ class Models:
         """
         model_id = Model._coerce_identifier(model)
 
-        # TODO: this was moved from the models api to the resources api, perhaps it should go in a different module?
         endpoint = "/resources/processing/models"
 
         result = self._api_client.http.get(endpoint)
@@ -362,6 +381,127 @@ class Models:
         self.logger.debug("body 2? %s", body)
         json_list = self._api_client.http.get('{}?{}'.format(self._base_route, urlencode(body)))
         return list(Model(json_obj, self._api_client) for json_obj in json_list)
+
+    def deploy(
+        self, container_image, model_name, model_version, sample_input_file, credentials=None, 
+        model_id=None, run_timeout=None, status_timeout=None, short_description=None, tags=[], 
+        gpu=False, long_description=None, technical_details=None, performance_summary=None,
+        performance_metrics=None, input_details=None, output_details=None
+        ):
+        """Deploys a new `Model` instance.
+
+        Args:
+            container_image (str): Docker container image to be deployed. This string should represent what follows a `docker pull` command. 
+            model_name (str): Name of model to be deployed
+            model_version (str): Versin of model to be deployed
+            sample_input_file (str): Path to local file to be used for sample inference
+            credentials (dict): Dictionary containing credentials if the container image is private. The keys in this dictionary must be `["user", "pass"]`
+            model_id (str): Model identifier if deploying a new version to a model that already exists
+            run_timeout (str): Timeout threshold for container `run` route
+            status_timeout (str): Timeout threshold for container `status` route
+            short_description (str): Short description to appear on model biography page
+            tags (list): List of tags to make model more discoverable in model library
+            gpu (bool): Flag for whether or not model requires GPU to run
+            long_description (str): Description to appear on model biography page
+            technical_details (str): Technical details to appear on model biography page. Markdown is accepted
+            performance_summary (str): Description providing model performance to appear on model biography page
+            performance_metrics (List): List of arrays describing model performance statistics
+            input_details (List): List of dictionaries describing details of model inputs
+            output_details (List): List of dictionaries describing details of model outputs
+
+        Returns:
+            dict: Newly deployed model information including formatted URL to newly deployed model page.
+        Raises:
+            ApiError: A subclass of ApiError will be raised if the API returns an error status,
+                or the client is unable to connect.
+        """ 
+        # generate model identifier and version to create new model        
+        if model_id:
+            identifier, version = model_id, model_version
+            # create new version of existing model
+            data = {"version": version}
+            try:
+                response = self._api_client.http.post(f"{self._base_route}/{identifier}/versions", data)
+            except BadRequestError as e:
+                raise e
+        else:
+            data = {'name': model_name, 'version': model_version}
+            response = self._api_client.http.post(self._base_route, data)
+            identifier, version = response.get('identifier'), model_version
+
+        self.logger.info(f"Created Model Version: {identifier}, {version}")
+
+        # add tags and description
+        tags_and_description = {
+            'description': short_description or ''
+        }
+        if len(tags) > 0:
+            tags_and_description['tags'] = tags
+        response = self._api_client.http.patch(f"{self._base_route}/{identifier}", tags_and_description)
+
+        # upload container image
+        m = re.search(self.container_registry_regex, container_image)
+        domain = m.group(1) or "registry.hub.docker.com/"
+        repository = m.group(2)
+        tag = m.group(3) or "latest"
+        image_url = "https://{}v2/{}/manifests/{}".format(domain, repository, tag)
+        registry = {'registry': {'url': image_url, 'username': credentials['user'], 'password': credentials['pass']}} if credentials else {'registry': {'url': image_url}}      
+        response = self._api_client.http.post(f"{self._base_route}/{identifier}/versions/{version}/container-image", registry)
+        self.logger.info("Uploaded Container Image")
+
+        # add model metadata
+        run_timeout_body = int(run_timeout)*1000 if run_timeout else 60000
+        status_timeout_body = int(status_timeout)*1000 if status_timeout else 60000
+
+        model_metadata = {
+            "requirement": {"requirementId": -6 if gpu else 1},
+            "timeout": {
+                "run": run_timeout_body,
+                "status": status_timeout_body
+            },
+            "inputs": input_details or self.default_inputs,
+            "outputs": output_details or self.default_outputs,    
+            "statistics": performance_metrics or [],
+            "processing": {
+                "minimumParallelCapacity": 0,
+                "maximumParallelCapacity": 1
+            },
+            "longDescription": long_description or "",
+            "technicalDetails": technical_details or "",
+            "performanceSummary": performance_summary or ""
+        }
+        model_data = self._api_client.http.patch(f"{self._base_route}/{identifier}/versions/{version}", model_metadata)
+        self.logger.info(f"Model Data: {json.dumps(model_data)}")
+
+        # load model container
+        try:
+            load_model(self._api_client, self.logger, identifier, version)
+        except Exception as e:
+            raise ValueError("Loading model container failed. Make sure you passed through a valid Docker registry container image. \n\nSee full error below:\n{}".format(e))
+        # upload sample data for inference test
+        try:
+            upload_input_example(self._api_client, self.logger, identifier, version, model_data, sample_input_file)
+        except Exception as e:
+            raise ValueError("Uploading sample input failed. \n\nSee full error below:\n{}".format(e))
+        # run sample inference
+        try:
+            run_model(self._api_client, self.logger, identifier, version)
+        except Exception as e:
+            raise ValueError("Inference test failed. Make sure the provided input sample is valid and your model can process it for inference. \n\nSee full error below:\n{}".format(e))
+        # deploy model pending all tests have passed
+        try:
+            deploy_model(self._api_client, self.logger, identifier, version)
+        except Exception as e:
+            raise ValueError("Deployment failed. Check to make sure all of your parameters and assets are valid and try again. \n\nSee full error below:\n{}".format(e))
+        
+        # get new model URL and return
+        base_url = self._api_client.base_url.split("api")[0][:-1] 
+        container_data = {
+            **model_data,
+            'container_url': f"{base_url}{self._base_route}/{identifier}/{version}"
+        }
+
+        return container_data
 
 
 class Model(ApiObject):

--- a/modzy/models.py
+++ b/modzy/models.py
@@ -391,9 +391,9 @@ class Models:
         """Deploys a new `Model` instance.
 
         Args:
-            container_image (str): Docker container image to be deployed. This string should represent what follows a `docker pull` command. 
+            container_image (str): Docker container image to be deployed. This string should represent what follows a `docker pull` command 
             model_name (str): Name of model to be deployed
-            model_version (str): Versin of model to be deployed
+            model_version (str): Version of model to be deployed
             sample_input_file (str): Path to local file to be used for sample inference
             credentials (dict): Dictionary containing credentials if the container image is private. The keys in this dictionary must be `["user", "pass"]`
             model_id (str): Model identifier if deploying a new version to a model that already exists
@@ -425,6 +425,7 @@ class Models:
             except BadRequestError as e:
                 raise e
         else:
+            # create new model object
             data = {'name': model_name, 'version': model_version}
             response = self._api_client.http.post(self._base_route, data)
             identifier, version = response.get('identifier'), model_version
@@ -443,7 +444,7 @@ class Models:
         m = re.search(self.container_registry_regex, container_image)
         domain = m.group(1) or "registry.hub.docker.com/"
         repository = m.group(2)
-        tag = m.group(3) or "latest"
+        tag = m.group(3) or "latest"        
         image_url = "https://{}v2/{}/manifests/{}".format(domain, repository, tag)
         registry = {'registry': {'url': image_url, 'username': credentials['user'], 'password': credentials['pass']}} if credentials else {'registry': {'url': image_url}}      
         response = self._api_client.http.post(f"{self._base_route}/{identifier}/versions/{version}/container-image", registry)
@@ -494,13 +495,12 @@ class Models:
         except Exception as e:
             raise ValueError("Deployment failed. Check to make sure all of your parameters and assets are valid and try again. \n\nSee full error below:\n{}".format(e))
         
-        # get new model URL and return
+        # get new model URL and return model data
         base_url = self._api_client.base_url.split("api")[0][:-1] 
         container_data = {
             **model_data,
             'container_url': f"{base_url}{self._base_route}/{identifier}/{version}"
         }
-
         return container_data
 
 

--- a/modzy/models.py
+++ b/modzy/models.py
@@ -498,7 +498,7 @@ class Models:
         # get new model URL and return model data
         base_url = self._api_client.base_url.split("api")[0][:-1] 
         container_data = {
-            **model_data,
+            'model_data': json.dumps(model_data),
             'container_url': f"{base_url}{self._base_route}/{identifier}/{version}"
         }
         return container_data

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -18,3 +18,10 @@ python-dotenv==0.19.0
 pytest-dotenv==0.5.2
 
 deprecation==2.1.0
+
+grpcio-tools
+grpcio
+grpcio-reflection
+protobuf==3.19.4
+pyyaml
+six

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -25,3 +25,4 @@ grpcio-reflection
 protobuf==3.19.4
 pyyaml
 six
+gcloud

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7'
     ],
-    description="Modzy's Python SDK queries models, submits inference jobs and returns results directly to your editor.",
+    description="Modzy's Python SDK queries and deploys models, submits inference jobs and returns results directly to your editor.",
     python_requires='>=3.6',
     install_requires=requirements,
     long_description=readme,


### PR DESCRIPTION
## Description

This PR adds programmatic support for model deployment via `client.models.deploy()`. The added method strings together several API endpoints required to deploy a new model from scratch. See full reference [here](https://docs.modzy.com/reference/model-deployment).

This method deploys any model that comes from any Docker registry that adheres to this [protocol](https://docs.docker.com/registry/spec/api/).

## Tests

The following scenarios were successfully tested:
1. Public container from Dockerhub ([container image link](https://hub.docker.com/layers/grpc-echo-model/modzy/grpc-echo-model/1.0.0/images/sha256-587489769788f49b2166bfdec655a429234bdc1e9e038136a5211fe84b0a90d6?context=repo))
2. Private container from Dockerhub (i.e., requires credentials)
3. Private container from AWS ECR (i.e., requires AWS Access Key and Secret Access Key)
4. Deploy new version of a model that already exists

## Checklist

- [x] I read the Contributing guide.
- [x] I updated the documentation and if the case the README.md file.
- [x] I am willing to follow-up on review comments in a timely manner.
