### PR TITLE
Feat/deploy arm

### DIFF
--- a/modzy/models.py
+++ b/modzy/models.py
@@ -448,7 +448,7 @@ class Models:
             container_image (str): Docker container image to be deployed. This string should represent what follows a `docker pull` command 
             model_name (str): Name of model to be deployed
             model_version (str): Version of model to be deployed
-            architecture (str): `{'amd64', 'arm64', 'arm'}` If set to `arm`, deploy method will expedite the deployment process and bypass some Modzy tests that are only available for x86 compiled models. 
+            architecture (str): `{'amd64', 'arm64', 'arm'}` If set to `arm64` or `arm`, deploy method will expedite the deployment process and bypass some Modzy tests that are only available for models compiled for amd64 chips. 
             sample_input_file (str): Path to local file to be used for sample inference
             credentials (dict): Dictionary containing credentials if the container image is private. The keys in this dictionary must be `["user", "pass"]`
             model_id (str): Model identifier if deploying a new version to a model that already exists


### PR DESCRIPTION
This PR contains the following changes to the `client.models.deploy()` method:
* Additional parameter, `arch` that represents the target architecture for the model that is being deployed. This mandatory parameter must be `amd` for all models compiled for x86, or `arm` for all models compiled for an architecture other than x86.
* If `arch` is set to `arm`, the deployment method will bypass a series of validation checks Modzy performs, which are only available for models compiled for x86 chip sets.

This PR also contains a new method, `client.models.edit_model_metadata()` that allows users to patch model metadata, including inputs and outputs, to a previously-deployed model. 